### PR TITLE
Update Build & Deploy workflow to 0.11.1

### DIFF
--- a/.github/workflows/moonscript_release.yml
+++ b/.github/workflows/moonscript_release.yml
@@ -1,5 +1,4 @@
 name: Create Moonscript Release
-:wa
 
 on:
   push:


### PR DESCRIPTION
This PR was automatically triggered due to [a change in the base `moonscript_release` workflow](https://github.com/CFC-Servers/github_action_workflows/compare/0.11..0.11.1)