### PR TITLE
Update moonscript_release workflow to 0.12.4

### DIFF
--- a/.github/workflows/moonscript_release.yml
+++ b/.github/workflows/moonscript_release.yml
@@ -79,4 +79,3 @@ jobs:
           asset_name: ${{ github.event.repository.name }}.zip
           asset_content_type: application/zip
 
-# forced_update_count: 2


### PR DESCRIPTION
This PR was automatically triggered due to [a change in the base `moonscript_release` workflow](https://github.com/CFC-Servers/github_action_workflows/compare/0.12.3..0.12.4)