### PR TITLE
Ignore damage-probing from certain ents

### DIFF
--- a/lua/powerups/server/phoenix.moon
+++ b/lua/powerups/server/phoenix.moon
@@ -4,6 +4,12 @@ import Rand, cos, sin from math
 import Create from ents
 import SpriteTrail from util
 
+IGNORED_INFLICTORS = { -- Inflictors that use damage to check for hittability, rather than actually dealing damage. Don't try to revive on these.
+    cfc_simple_ent_antigrav_grenade: true
+    cfc_simple_ent_bubble_grenade: true
+    cfc_simple_ent_curse_grenade: true
+}
+
 export PhoenixPowerup
 class PhoenixPowerup extends BasePowerup
     @powerupID: "powerup_phoenix"
@@ -228,3 +234,10 @@ hook.Add "CFC_Powerups_DisallowGetPowerup", "CFC_Powerups-Phoenix-EnforceUseLimi
     return unless existingPowerup.UsesRemaining >= maxUses
 
     return true, "You're maxed out on Phoenix uses"
+
+hook.Add "CFC_Powerups-Phoenix-ShouldIgnoreDamage", "CFC_Powerups-Phoenix-IgnoredInflictors", (_, damageInfo) ->
+    inflictor = damageInfo\GetInflictor!
+    return unless IsValid inflictor
+    return unless IGNORED_INFLICTORS[inflictor\GetClass!]
+
+    return true

--- a/lua/powerups/server/phoenix.moon
+++ b/lua/powerups/server/phoenix.moon
@@ -4,7 +4,9 @@ import Rand, cos, sin from math
 import Create from ents
 import SpriteTrail from util
 
-IGNORED_INFLICTORS = { -- Inflictors that use damage to check for hittability, rather than actually dealing damage. Don't try to revive on these.
+-- Inflictors that use damage to check for hittability, rather than actually dealing damage.
+-- Makes the Phoenix powerup not try to revive on these.
+IGNORED_INFLICTORS = {
     cfc_simple_ent_antigrav_grenade: true
     cfc_simple_ent_bubble_grenade: true
     cfc_simple_ent_curse_grenade: true


### PR DESCRIPTION
Prevents the damage-probing checks from certain cfc_pvp_weapons grenades from triggering Phoenix revives, as they self-block the damage.